### PR TITLE
 商品に購入希望を出せるようにした

### DIFF
--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PurchaseRequestsController < ApplicationController
   def create
     item = Item.find(params[:item_id])

--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -1,7 +1,13 @@
 class PurchaseRequestsController < ApplicationController
   def create
+    item = Item.find(params[:item_id])
+    current_user.purchase_requests.create!(item:)
+    redirect_to item, notice: '購入希望を出しました'
   end
 
   def destroy
+    purchase_request = current_user.purchase_requests.find(params[:id])
+    purchase_request.destroy!
+    redirect_to purchase_request.item, notice: '購入希望を取り消しました', status: :see_other
   end
 end

--- a/app/controllers/purchase_requests_controller.rb
+++ b/app/controllers/purchase_requests_controller.rb
@@ -1,0 +1,7 @@
+class PurchaseRequestsController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/helpers/purchase_requests_helper.rb
+++ b/app/helpers/purchase_requests_helper.rb
@@ -1,0 +1,2 @@
+module PurchaseRequestsHelper
+end

--- a/app/helpers/purchase_requests_helper.rb
+++ b/app/helpers/purchase_requests_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module PurchaseRequestsHelper
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,8 @@
 
 class Item < ApplicationRecord
   belongs_to :user
+  has_many :purchase_requests, dependent: :destroy
+  has_many :requesting_users, through: :purchase_requests, source: :user
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/purchase_request.rb
+++ b/app/models/purchase_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PurchaseRequest < ApplicationRecord
   belongs_to :user
   belongs_to :item

--- a/app/models/purchase_request.rb
+++ b/app/models/purchase_request.rb
@@ -1,0 +1,7 @@
+class PurchaseRequest < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+
+  validates :user, presence: true, uniqueness: { scope: :item }
+  validates :item, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 class User < ApplicationRecord
   has_many :items, dependent: :destroy
+  has_many :purchase_requests, dependent: :destroy
+  has_many :requested_items, through: :purchase_requests, source: :item
 
   devise :omniauthable, omniauth_providers: [:discord]
 

--- a/app/views/items/_item.html.slim
+++ b/app/views/items/_item.html.slim
@@ -27,3 +27,7 @@ div id="#{dom_id item}"
     strong.block.font-medium.mb-1
       | User:
     = item.user.name
+  p.my-5
+    strong.block.font-medium.mb-1
+      | 現在の購入希望数:
+    = item.purchase_requests.size

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -4,6 +4,16 @@
       p#notice.py-2.px-3.bg-green-50.mb-5.text-green-500.font-medium.rounded-lg.inline-block
         = notice
     = render @item
+    - if @item.user != current_user
+      - purchase_request = @item.purchase_requests.find_by(user_id: current_user.id)
+      - if purchase_request
+        p.py-2.px-3.bg-yellow-50.mb-5.text-yellow-500.font-medium.rounded-lg
+          | 購入希望を出しています
+        .inline-block.mr-2
+          = button_to '購入希望を取り消す', item_purchase_request_path(@item, purchase_request), method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-red-600 text-white font-medium'
+      - else
+        .inline-block.mr-2
+          = button_to '購入希望を出す', item_purchase_requests_path(@item), class: 'mt-2 rounded-lg py-3 px-5 bg-blue-600 text-white font-medium'
     - if @item.user == current_user
       = link_to 'Edit this item', edit_item_path(@item), class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'
     = link_to 'Back to items', items_path, class: 'ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :items
+  resources :items do
+    resources :purchase_requests, only: [:create, :destroy]
+  end
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do

--- a/db/migrate/20240705023306_create_purchase_requests.rb
+++ b/db/migrate/20240705023306_create_purchase_requests.rb
@@ -1,0 +1,12 @@
+class CreatePurchaseRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :purchase_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :purchase_requests, %i[user_id item_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_04_110126) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_023306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_110126) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchase_requests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_purchase_requests_on_item_id"
+    t.index ["user_id", "item_id"], name: "index_purchase_requests_on_user_id_and_item_id", unique: true
+    t.index ["user_id"], name: "index_purchase_requests_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "uid", null: false
@@ -38,4 +48,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_110126) do
   end
 
   add_foreign_key "items", "users"
+  add_foreign_key "purchase_requests", "items"
+  add_foreign_key "purchase_requests", "users"
 end

--- a/spec/factories/purchase_requests.rb
+++ b/spec/factories/purchase_requests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :purchase_request do
     user { nil }

--- a/spec/factories/purchase_requests.rb
+++ b/spec/factories/purchase_requests.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :purchase_request do
+    user { nil }
+    item { nil }
+  end
+end

--- a/spec/models/purchase_request_spec.rb
+++ b/spec/models/purchase_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseRequest, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/purchase_request_spec.rb
+++ b/spec/models/purchase_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PurchaseRequest, type: :model do


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/37

以下の作業を行った。

- PurchaseRequestモデル・コントローラーの作成
  - ルーティングはitemsにネストされるリソースフルルーティング（create, destroyのみ）
- 商品ページ上に購入希望を出すボタンを置く 
- 購入希望を出している商品ページ上に購入希望を取り下げるボタンを置く
- 商品に対する現在の購入希望者数を表示できるようにする