### PR TITLE
商品の購入者の決定（当選）機能の作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/config/schedule.rb

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'slim_lint', require: false
+  gem 'whenever', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -376,6 +377,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.16)
@@ -415,6 +418,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.3.3p89

--- a/app/controllers/listed_items_controller.rb
+++ b/app/controllers/listed_items_controller.rb
@@ -2,6 +2,17 @@
 
 class ListedItemsController < ApplicationController
   def index
-    @items = current_user.items.by_status(params[:status])
+    items = current_user.items
+    @items =
+      case params[:status]
+      when 'listed'
+        items.listed
+      when 'unpublished'
+        items.unpublished
+      when 'buyer_selected'
+        items.buyer_selected
+      else
+        items
+      end
   end
 end

--- a/app/controllers/requested_items_controller.rb
+++ b/app/controllers/requested_items_controller.rb
@@ -2,7 +2,17 @@
 
 class RequestedItemsController < ApplicationController
   def index
-    # TODO: 当選機能を実装したら、statusによって表示するアイテムを絞り込むようにする
-    @items = current_user.requested_items
+    items = current_user.requested_items
+    @items =
+      case params[:status]
+      when 'requested'
+        items.listed
+      when 'selected_as_buyer'
+        items.where(buyer: current_user)
+      when 'not_selected'
+        items.buyer_selected.where.not(buyer: current_user)
+      else
+        items
+      end
   end
 end

--- a/app/models/buyer_selector.rb
+++ b/app/models/buyer_selector.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class BuyerSelector
+  def initialize(item)
+    @item = item
+    @purchase_requests = @item.purchase_requests
+  end
+
+  def select_buyer!
+    if @purchase_requests.exists?
+      buyer = @purchase_requests.sample.user
+      @item.assign_attributes(buyer:, status: :buyer_selected)
+    else
+      @item.status = :unpublished
+    end
+    @item.save!(context: :select_buyer)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item < ApplicationRecord
   validates :deadline, presence: true
   validate :deadline_later_than_today, unless: -> { validation_context == :select_buyer }
 
-  scope :accessible_for, ->(user) { where(user:).or(listed) }
+  scope :accessible_for, ->(user) { where(user:).or(not_unpublished) }
   scope :closed_yesterday, -> { listed.where('deadline < ?', Time.current.beginning_of_day) }
   scope :by_status, lambda { |status|
     case status

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@
 
 class Item < ApplicationRecord
   belongs_to :user
+  belongs_to :buyer, class_name: 'User', optional: true, inverse_of: :buyable_items
   has_many :purchase_requests, dependent: :destroy
   has_many :requesting_users, through: :purchase_requests, source: :user
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,7 @@ class Item < ApplicationRecord
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :shipping_cost_covered, inclusion: { in: [true, false] }
   validates :deadline, presence: true
-  validate :deadline_later_than_today
+  validate :deadline_later_than_today, unless: -> { validation_context == :select_buyer }
 
   scope :accessible_for, ->(user) { where(user:).or(listed) }
   scope :by_status, lambda { |status|

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,14 +17,6 @@ class Item < ApplicationRecord
 
   scope :accessible_for, ->(user) { where(user:).or(not_unpublished) }
   scope :closed_yesterday, -> { listed.where('deadline < ?', Time.current.beginning_of_day) }
-  scope :by_status, lambda { |status|
-    case status
-    when 'listed'
-      listed
-    when 'unpublished'
-      unpublished
-    end
-  }
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,6 +13,7 @@ class Item < ApplicationRecord
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :shipping_cost_covered, inclusion: { in: [true, false] }
   validates :deadline, presence: true
+  validate :deadline_later_than_today
 
   scope :accessible_for, ->(user) { where(user:).or(listed) }
   scope :by_status, lambda { |status|
@@ -23,4 +24,12 @@ class Item < ApplicationRecord
       unpublished
     end
   }
+
+  private
+
+  def deadline_later_than_today
+    return unless deadline < Time.current.beginning_of_day
+
+    errors.add(:deadline, "can't be later than today")
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,6 +16,7 @@ class Item < ApplicationRecord
   validate :deadline_later_than_today, unless: -> { validation_context == :select_buyer }
 
   scope :accessible_for, ->(user) { where(user:).or(listed) }
+  scope :closed_yesterday, -> { listed.where('deadline < ?', Time.current.beginning_of_day) }
   scope :by_status, lambda { |status|
     case status
     when 'listed'

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   has_many :purchase_requests, dependent: :destroy
   has_many :requesting_users, through: :purchase_requests, source: :user
 
-  enum status: { listed: 0, unpublished: 1 }
+  enum status: { listed: 0, unpublished: 1, buyer_selected: 2 }
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :items, dependent: :destroy
+  has_many :buyable_items, class_name: 'Item', foreign_key: :buyer_id, inverse_of: :buyer, dependent: :nullify
   has_many :purchase_requests, dependent: :destroy
   has_many :requested_items, through: :purchase_requests, source: :item
 

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -3,21 +3,35 @@
     - if notice.present?
       p#notice.py-2.px-3.bg-green-50.mb-5.text-green-500.font-medium.rounded-lg.inline-block
         = notice
-    - if @item.unpublished?
-      p.py-2.px-3.bg-red-50.mb-5.text-red-500.font-medium.rounded-lg
-        | この商品は非公開です
+    - if @item.user == current_user
+      - if @item.unpublished?
+        p.py-2.px-3.bg-gray-300.mb-5.text-gray-800.font-medium.rounded-lg
+          | この商品は非公開です
+      - if @item.buyer_selected?
+        p.py-2.px-3.bg-yellow-300.mb-5.text-yellow-800.font-medium.rounded-lg
+          | 購入者が確定しました
     = render @item
     - if @item.user != current_user
       - purchase_request = @item.purchase_requests.find_by(user_id: current_user.id)
       - if purchase_request
-        p.py-2.px-3.bg-yellow-50.mb-5.text-yellow-500.font-medium.rounded-lg
-          | 購入希望を出しています
-        .inline-block.mr-2
-          = button_to '購入希望を取り消す', item_purchase_request_path(@item, purchase_request), method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-red-600 text-white font-medium'
+        - if @item.listed?
+          p.py-2.px-3.bg-blue-600.mb-5.text-white.font-medium.rounded-lg
+            | 購入希望を出しています
+          .inline-block.mr-2
+            = button_to '購入希望を取り消す', item_purchase_request_path(@item, purchase_request), method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-red-600 text-white font-medium'
+        - if @item.buyer == current_user
+          p.py-2.px-3.bg-yellow-300.mb-5.text-yellow-800.font-medium.rounded-lg
+            | あなたが購入者となりました
+        - if @item.buyer_selected? && @item.buyer != current_user
+          p.py-2.px-3.bg-gray-300.mb-5.text-gray-800.font-medium.rounded-lg
+            | 落選しました
+      - elsif @item.buyer_selected?
+        p.py-2.px-3.bg-red-50.mb-5.text-red-500.font-medium.rounded-lg
+          | 終了しました
       - else
         .inline-block.mr-2
           = button_to '購入希望を出す', item_purchase_requests_path(@item), class: 'mt-2 rounded-lg py-3 px-5 bg-blue-600 text-white font-medium'
-    - if @item.user == current_user
+    - if @item.user == current_user && !@item.buyer_selected?
       = link_to 'Edit this item', edit_item_path(@item), class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'
     = link_to 'Back to items', items_path, class: 'ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'
     - if @item.user == current_user

--- a/app/views/listed_items/index.html.slim
+++ b/app/views/listed_items/index.html.slim
@@ -6,6 +6,7 @@
   .flex.items-center.mt-3
     = link_to 'すべて', listed_items_path, class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
     = link_to '出品中', listed_items_path(status: 'listed'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
+    = link_to '購入者確定', listed_items_path(status: 'buyer_selected'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
     = link_to '非公開', listed_items_path(status: 'unpublished'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
   #items.min-w-full
     - @items.each do |item|
@@ -16,6 +17,9 @@
       - when 'unpublished'
         p.mt-3.bg-gray-300.text-gray-800.py-1.px-2.rounded-lg.inline-block
           | 非公開
+      - when 'buyer_selected'
+        p.mt-3.bg-yellow-300.text-yellow-800.py-1.px-2.rounded-lg.inline-block
+          | 購入者確定
       = render item
       p
         = link_to 'Show this item', item, class: 'ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'

--- a/app/views/requested_items/index.html.slim
+++ b/app/views/requested_items/index.html.slim
@@ -4,15 +4,21 @@
     h1.font-bold.text-4xl
       | 自分が購入希望を出した商品一覧
   .flex.items-center.mt-3
-    // TODO: 抽選機能を実装したら、状態に応じてソートできるようにする
     = link_to 'すべて', requested_items_path, class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
+    = link_to '購入希望中', requested_items_path(status: 'requested'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
+    = link_to '購入確定', requested_items_path(status: 'selected_as_buyer'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
+    = link_to '落選', requested_items_path(status: 'not_selected'), class: 'ml-2 rounded-lg py-1 px-2 bg-gray-100 inline-block font-medium'
   #items.min-w-full
     - @items.each do |item|
-      // TODO: 抽選機能を実装したら、抽選が終わった状態の条件分岐を増やす
-      - case item.status
-      - when 'listed'
+      - if item.status == 'listed'
         p.mt-3.bg-blue-600.text-white.py-1.px-2.rounded-lg.inline-block
           | 購入希望中
+      - if item.buyer == current_user
+        p.mt-3.bg-yellow-300.text-yellow-800.py-1.px-2.rounded-lg.inline-block
+          | 購入確定
+      - if item.buyer_selected? && item.buyer != current_user
+        p.mt-3.bg-gray-300.text-gray-800.py-1.px-2.rounded-lg.inline-block
+          | 落選
       = render item
       p
         = link_to 'Show this item', item, class: 'ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'

--- a/db/migrate/20240707042146_add_buyer_to_items.rb
+++ b/db/migrate/20240707042146_add_buyer_to_items.rb
@@ -1,0 +1,5 @@
+class AddBuyerToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :items, :buyer, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_06_033731) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_07_042146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_033731) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
+    t.bigint "buyer_id"
+    t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
@@ -49,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_033731) do
   end
 
   add_foreign_key "items", "users"
+  add_foreign_key "items", "users", column: "buyer_id"
   add_foreign_key "purchase_requests", "items"
   add_foreign_key "purchase_requests", "users"
 end

--- a/lib/tasks/select_buyer.rake
+++ b/lib/tasks/select_buyer.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :items do
+  desc 'Select winners for items whose deadline has passed and no winner has been chosen yet'
+  task select_buyers: :environment do
+    items = Item.closed_yesterday
+
+    items.find_each do |item|
+      buyer_selector = BuyerSelector.new(item)
+      buyer_selector.select_buyer!
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/41

以下の作業を行った。

- Itemモデルに抽選が終わった状態を表すステータスのenumの識別子を設定(buyer_selected)
- Itemモデルにbuyer_id(当選者)カラムを追加
- 抽選作業を行うRakeタスクの作成
  - 締切が昨日より前の商品を検索する
  - 紐づく購入希望者の中からランダムで一人を選び、buyer_idを設定する
  - 抽選が終わった状態のステータス(buyer_selected)にする
- 抽選が終わった商品ページにその旨を表示する
- 購入希望を出していたユーザーの購入希望商品一覧ページに、「当選」「落選」に相当するソート機能を作る
- cronを開発環境で検証しやすいようにwheneverを導入