### PR TITLE
商品のCRUD関連のシステムテストの追加

### DIFF
--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,12 +2,27 @@
 
 FactoryBot.define do
   factory :item do
-    name { 'MyString' }
-    description { 'MyText' }
-    price { 1 }
-    shipping_cost_covered { false }
-    payment_method { 'MyString' }
-    deadline { '2024-07-04 20:01:26' }
+    name { 'テスト商品' }
+    description { 'テスト商品です' }
+    price { 1000 }
+    shipping_cost_covered { true }
+    payment_method { 'PayPay' }
+    deadline { Time.current.tomorrow }
     user { nil }
+    status { 0 }
+
+    factory :unpublished_item do
+      name { '非公開商品' }
+      description { '非公開商品です' }
+      status { 1 }
+    end
+
+    # 購入確定済みの場合、deadlineは本来過去の日付になるべきだが、create時にバリデーションで弾かれるため、未来の日付のままにしている
+    # 厳密なデータを作成する場合は、使用するテスト側で過去の日付を設定してbuildし、バリデーションを無効にしてsaveする
+    factory :buyer_selected_item do
+      name { '購入者確定済みの商品' }
+      description { '購入者確定済みの商品です' }
+      status { 2 }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user do
     name { 'alice' }
-    uid { '1234567' }
+    sequence(:uid) { |n| "1234567#{n}" }
     provider { 'discord' }
     avatar_url { 'https://cdn.discordapp.com/embed/avatars/1.png' }
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Items', type: :system do
+  let(:alice) { FactoryBot.create(:user) }
+  let(:bob) { FactoryBot.create(:user, name: 'bob') }
+  let(:carol) { FactoryBot.create(:user, name: 'carol') }
+
+  describe 'listing items' do
+    it 'user can list an item' do
+      sign_in alice
+      visit items_path
+      click_on 'New item'
+      fill_in 'Name', with: 'テスト商品'
+      fill_in 'Price', with: 1000
+      fill_in 'Description', with: 'テスト商品です'
+      check 'Shipping cost covered'
+      fill_in 'Payment method', with: 'PayPay'
+      fill_in 'Deadline', with: Time.current.tomorrow
+      click_on '出品する'
+      expect(page).to have_content 'Item was successfully created.'
+      expect(page).to have_content 'テスト商品'
+    end
+
+    it 'user can save an item as unpublished' do
+      sign_in alice
+      visit items_path
+      click_on 'New item'
+      fill_in 'Name', with: '非公開商品'
+      fill_in 'Description', with: '非公開商品です'
+      fill_in 'Price', with: 1000
+      check 'Shipping cost covered'
+      fill_in 'Payment method', with: 'PayPay'
+      fill_in 'Deadline', with: Time.current.tomorrow
+      click_on '非公開として保存'
+      expect(page).to have_content 'Item was successfully created.'
+      expect(page).to have_content 'この商品は非公開です'
+    end
+  end
+
+  describe 'editing and destroying items' do
+    let(:item) { FactoryBot.create(:item, user: alice) }
+    let(:unpublished_item) { FactoryBot.create(:unpublished_item, user: alice) }
+
+    context 'when user owns their own item' do
+      it 'user can edit their own item' do
+        sign_in alice
+        visit item_path(item)
+        click_on 'Edit this item'
+        fill_in 'Name', with: '編集済み商品'
+        click_on '出品する'
+        expect(page).to have_content 'Item was successfully updated.'
+        expect(page).to have_content '編集済み商品'
+      end
+
+      it 'user can destroy their own item' do
+        sign_in alice
+        visit item_path(item)
+        click_on 'Destroy this item'
+        expect(page).to have_content 'Item was successfully destroyed.'
+        expect(page).not_to have_content item.name
+      end
+    end
+
+    context "when user tries to edit or destroy another user's item" do
+      it "user can't edit and destroy another user's item" do
+        sign_in bob
+        visit item_path(item)
+        expect(page).not_to have_content 'Edit this item'
+        expect(page).not_to have_content 'Destroy this item'
+      end
+    end
+
+    context 'when user edits items as unpublished' do
+      it 'user can make a listed item unpublished' do
+        sign_in alice
+        visit item_path(item)
+        expect(page).not_to have_content 'この商品は非公開です'
+        click_on 'Edit this item'
+        click_on '非公開として保存'
+        expect(page).to have_content 'Item was successfully updated.'
+        expect(page).to have_content 'この商品は非公開です'
+      end
+
+      it 'user can make an unpublished item listed' do
+        sign_in alice
+        visit item_path(unpublished_item)
+        expect(page).to have_content 'この商品は非公開です'
+        click_on 'Edit this item'
+        click_on '出品する'
+        expect(page).to have_content 'Item was successfully updated.'
+        expect(page).not_to have_content 'この商品は非公開です'
+      end
+    end
+  end
+
+  describe 'indexing items' do
+    it 'user can see currently listed items' do
+      item = FactoryBot.create(:item, user: alice)
+      unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
+      buyer_selected_item = FactoryBot.create(:buyer_selected_item, user: alice, buyer: bob)
+
+      sign_in alice
+      visit items_path
+      expect(page).to have_content '現在出品されている商品一覧'
+      expect(page).to have_content item.name
+      expect(page).not_to have_content unpublished_item.name
+      expect(page).not_to have_content buyer_selected_item.name
+    end
+  end
+
+  describe 'showing items' do
+    context 'when user checks their own item' do
+      it 'user can see a label about the status of an each item' do
+        unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
+        buyer_selected_item = FactoryBot.create(:buyer_selected_item, user: alice, buyer: bob)
+        sign_in alice
+        visit item_path(unpublished_item)
+        expect(page).to have_content 'この商品は非公開です'
+        visit item_path(buyer_selected_item)
+        expect(page).to have_content '購入者が確定しました'
+      end
+    end
+
+    context "when user checks another user's item" do
+      it 'user can see a label about the status of an each item' do
+        currently_requesting_item = FactoryBot.create(:item, user: bob)
+        FactoryBot.create(:purchase_request, item: currently_requesting_item, user: alice)
+        selected_as_buyer_item = FactoryBot.create(:buyer_selected_item, user: bob, buyer: alice)
+        FactoryBot.create(:purchase_request, item: selected_as_buyer_item, user: alice)
+        not_selected_as_buyer_item = FactoryBot.create(:buyer_selected_item, user: bob, buyer: carol)
+        FactoryBot.create(:purchase_request, item: not_selected_as_buyer_item, user: alice)
+        just_selection_finished_item = FactoryBot.create(:buyer_selected_item, user: bob, buyer: carol)
+
+        sign_in alice
+        visit item_path(currently_requesting_item)
+        expect(page).to have_content '購入希望を出しています'
+        visit item_path(selected_as_buyer_item)
+        expect(page).to have_content 'あなたが購入者となりました'
+        visit item_path(not_selected_as_buyer_item)
+        expect(page).to have_content '落選しました'
+        visit item_path(just_selection_finished_item)
+        expect(page).to have_content '終了しました'
+      end
+    end
+  end
+end


### PR DESCRIPTION
以下のことについてのテストを追加した。

- 自分の商品のCRUDについて
  - 非公開として保存・更新
- 商品ページを見ることについて
  - 商品の状態に応じたラベルが表示されることについて
    - 自分の持ち物としてのラベル
      - 非公開・確定ラベル
    - 自分が購入希望者としてのラベル
      - 購入希望中・当選・落選ラベル
    - なにもしておらず終了
      - 終了ラベル
- 商品一覧を見ることについて
  - 非公開・終了の商品は含まれない
- 他人の商品の編集はできない（編集リンクがない）
- 他人の商品の削除はできない（削除ボタンがない）