### PR TITLE
自分が出品した商品一覧ページに関連するシステムテストを追加

### DIFF
--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
 
     factory :unpublished_item do
       name { '非公開商品' }
-      description { '非公開商品です' }
       status { 1 }
     end
 
@@ -21,7 +20,6 @@ FactoryBot.define do
     # 厳密なデータを作成する場合は、使用するテスト側で過去の日付を設定してbuildし、バリデーションを無効にしてsaveする
     factory :buyer_selected_item do
       name { '購入者確定済みの商品' }
-      description { '購入者確定済みの商品です' }
       status { 2 }
     end
   end

--- a/spec/system/listed_items_spec.rb
+++ b/spec/system/listed_items_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ListedItems', type: :system do
+  let(:alice) { FactoryBot.create(:user) }
+  let(:bob) { FactoryBot.create(:user, name: 'bob') }
+
+  before do
+    FactoryBot.create(:item, name: '出品中の商品', user: alice)
+    FactoryBot.create(:unpublished_item, name: '非公開の商品', user: alice)
+    FactoryBot.create(:buyer_selected_item, name: '購入者確定の商品', user: alice, buyer: bob)
+  end
+
+  it 'user can check all of their own items' do
+    sign_in alice
+    visit listed_items_path
+    expect(page).to have_content '出品中の商品'
+    expect(page).to have_content '非公開の商品'
+    expect(page).to have_content '購入者確定の商品'
+  end
+
+  it 'user can filter items by status' do
+    sign_in alice
+    visit listed_items_path
+    click_on '出品中'
+    expect(page).to have_content '出品中の商品'
+    expect(page).not_to have_content '非公開の商品'
+    expect(page).not_to have_content '購入者確定の商品'
+
+    click_on '非公開'
+    expect(page).not_to have_content '出品中の商品'
+    expect(page).to have_content '非公開の商品'
+    expect(page).not_to have_content '購入者確定の商品'
+
+    click_on '購入者確定'
+    expect(page).not_to have_content '出品中の商品'
+    expect(page).not_to have_content '非公開の商品'
+    expect(page).to have_content '購入者確定の商品'
+  end
+end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/75

自分の商品一覧ページで、以下の商品が表示・ソートできることについてのテストを追加した。

- すべての商品
- 出品中
- 非公開
- 購入者確定