### PR TITLE
GitHub Actions によるCIのテスト設定ファイルを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: assets precompile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: "test"
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          bundler-cache: true
+      - name: assets precompile
+        run: bundle exec rake assets:precompile
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+      - name: Run tests
+        run: bundle exec rspec

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Add to patch a zietwerk loading error due to not using ActionMailer with devise
+if Rails.autoloaders.zeitwerk_enabled?
+  class Devise::Mailer; end
+end
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/6

GitHub Actions でRSpecによるテストを行うための設定ファイルを追加。

また、`--skip-action-mailer`したことにより、devise内部ファイル内で`Devise::Mailer`クラスが宣言されず、そのことによりCI上でZeitwerkによる自動読み込みでエラーが発生することが判明。
https://github.com/junohm410/fjord-flea-market/actions/runs/9949633296/job/27486184356

```
An error occurred while loading ./spec/models/item_spec.rb.
Failure/Error: require_relative '../config/environment'

Zeitwerk::NameError:
  expected file /home/runner/work/fjord-flea-market/fjord-flea-market/vendor/bundle/ruby/3.3.0/gems/devise-4.9.4/app/mailers/devise/mailer.rb to define constant Devise::Mailer, but didn't
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/callbacks.rb:32:in `on_file_autoloaded'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/kernel.rb:27:in `require'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/cref.rb:91:in `const_get'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/cref.rb:91:in `get'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:173:in `block in actual_eager_load_dir'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/helpers.rb:47:in `block in ls'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/helpers.rb:25:in `each'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/helpers.rb:25:in `ls'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:168:in `actual_eager_load_dir'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:16:in `each'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:[10](https://github.com/junohm410/fjord-flea-market/actions/runs/9949633296/job/27486184356#step:7:11):in `synchronize'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader.rb:413:in `block in eager_load_all'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader.rb:4[11](https://github.com/junohm410/fjord-flea-market/actions/runs/9949633296/job/27486184356#step:7:12):in `each'
# ./vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.16/lib/zeitwerk/loader.rb:411:in `eager_load_all'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/application/finisher.rb:80:in `block in <module:Finisher>'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `instance_exec'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `run'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:61:in `block in run_initializers'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:60:in `run_initializers'
# ./vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/application.rb:426:in `initialize!'
# ./config/environment.rb:5:in `<top (required)>'
# ./spec/rails_helper.rb:6:in `require_relative'
# ./spec/rails_helper.rb:6:in `<top (required)>'
# ./spec/models/item_spec.rb:3:in `<top (required)>'
```

deviseリポジトリ上のIssueを参考に、空の`Devise::Mailer`を宣言することでエラーを回避する修正を行った。