### PR TITLE
購入希望者が誰もつかずに締め切りを迎えた商品のDiscord通知を実装した

### DIFF
--- a/app/models/discord_driver.rb
+++ b/app/models/discord_driver.rb
@@ -6,24 +6,30 @@ class DiscordDriver
 
     client.execute do |builder|
       embed_message = params[:embed_message]
-      item_field = params[:embed_message][:item_field]
 
       builder.content = params[:body]
-      builder.username = 'FBCフリマ'
-      builder.add_embed do |embed|
-        embed.title = embed_message[:title]
-        embed.url = embed_message[:url]
-        embed.description = embed_message[:description]
-        embed.timestamp = embed_message[:timestamp]
+      builder.username = params[:sender_name] || 'FBCフリマ'
+      add_embed(builder, embed_message) if embed_message.present?
+    end
+  end
 
-        embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(**embed_message[:thumbnail])
-        embed.author = Discordrb::Webhooks::EmbedAuthor.new(**embed_message[:author])
+  private
 
-        embed.add_field(name: '価格', value: item_field[:price])
-        embed.add_field(name: '購入希望の締切日', value: item_field[:deadline])
-        embed.add_field(name: '配送料の負担', value: item_field[:shipping], inline: true)
-        embed.add_field(name: '希望する支払い方法', value: item_field[:payment], inline: true)
-      end
+  def add_embed(builder, embed_message)
+    item_field = embed_message[:item_field]
+    builder.add_embed do |embed|
+      embed.title = embed_message[:title]
+      embed.url = embed_message[:url]
+      embed.description = embed_message[:description]
+      embed.timestamp = embed_message[:timestamp]
+
+      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(**embed_message[:thumbnail])
+      embed.author = Discordrb::Webhooks::EmbedAuthor.new(**embed_message[:author])
+
+      embed.add_field(name: '価格', value: item_field[:price])
+      embed.add_field(name: '購入希望の締切日', value: item_field[:deadline])
+      embed.add_field(name: '配送料の負担', value: item_field[:shipping], inline: true)
+      embed.add_field(name: '希望する支払い方法', value: item_field[:payment], inline: true)
     end
   end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -14,4 +14,13 @@ class DiscordNotifier < AbstractNotifier::Base
       embed_message:
     )
   end
+
+  def buyer_not_selected(params = {})
+    params.merge!(@params)
+    item = params[:item]
+
+    notification(
+      body: "<@#{item.user.uid}> さんの「#{item.name}」は購入希望者がつかずに出品が終了しました。"
+    )
+  end
 end

--- a/lib/tasks/select_buyer.rake
+++ b/lib/tasks/select_buyer.rake
@@ -8,6 +8,9 @@ namespace :items do
     items.find_each do |item|
       buyer_selector = BuyerSelector.new(item)
       buyer_selector.select_buyer!
+
+      item.reload
+      DiscordNotifier.with(item:).buyer_not_selected.notify_now if item.unpublished?
     end
   end
 end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/102

購入希望者が誰もつかずに締め切りを迎えた商品のDiscord通知を実装した。
※下のスクショでは、開発環境上に入れている出品者ユーザーの`uid`がDiscordに存在しない架空のidのため、「不明なユーザー」となっている。

![image](https://github.com/user-attachments/assets/93ddba08-1fa9-4d4f-bca4-c1c75d411e9f)
