### PR TITLE
商品が公開から非公開になったら、購入希望者を0にする機能を実装した

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,6 +38,7 @@ class ItemsController < ApplicationController
   def update
     set_unpublished
     if @item.update(item_params)
+      @item.purchase_requests.destroy_all if @item.changed_to_unpublished_from_listed?
       DiscordNotifier.with(item: @item).item_listed.notify_now if @item.changed_to_listed_from_unpublished?
       redirect_to @item, notice: 'Item was successfully updated.', status: :see_other
     else

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,6 +24,10 @@ class Item < ApplicationRecord
     saved_change_to_status == %w[unpublished listed]
   end
 
+  def changed_to_unpublished_from_listed?
+    saved_change_to_status == %w[listed unpublished]
+  end
+
   private
 
   def deadline_later_than_today

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -64,4 +64,36 @@ RSpec.describe Item, type: :model do
       end
     end
   end
+
+  describe 'changed_to_unpublished_from_listed?' do
+    context 'when an item status has changed from listed to unpublished' do
+      it 'returns true' do
+        item = FactoryBot.create(:item, user: alice)
+        item.status = 'unpublished'
+        item.save
+        expect(item.changed_to_unpublished_from_listed?).to be true
+      end
+    end
+
+    context 'when an item status has changed from unpublished to listed' do
+      it 'returns false' do
+        item = FactoryBot.create(:unpublished_item, user: alice)
+        item.status = 'listed'
+        item.save
+        expect(item.changed_to_unpublished_from_listed?).to be false
+      end
+    end
+
+    context 'when an item status has not changed' do
+      it 'returns false' do
+        listed_item = FactoryBot.create(:item, user: alice)
+        listed_item.update(name: '更新後の商品名')
+        expect(listed_item.changed_to_unpublished_from_listed?).to be false
+
+        unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
+        unpublished_item.update(name: '更新後の商品名')
+        expect(unpublished_item.changed_to_unpublished_from_listed?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Item, type: :model do
         expect(item.changed_to_listed_from_unpublished?).to be false
       end
     end
+
+    context 'when an item status has not changed' do
+      it 'returns false' do
+        listed_item = FactoryBot.create(:item, user: alice)
+        listed_item.update(name: '更新後の商品名')
+        expect(listed_item.changed_to_unpublished_from_listed?).to be false
+
+        unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
+        unpublished_item.update(name: '更新後の商品名')
+        expect(unpublished_item.changed_to_unpublished_from_listed?).to be false
+      end
+    end
   end
 
   describe 'changed_to_unpublished_from_listed?' do

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe 'Items', type: :system do
         expect(page).to have_content 'Item was successfully updated.'
         expect(page).not_to have_content 'この商品は非公開です'
       end
+
+      it 'purchase requests are deleted when an item is made unpublished' do
+        FactoryBot.create(:purchase_request, item:, user: bob)
+        sign_in alice
+        visit item_path(item)
+        click_on 'Edit this item'
+        expect do
+          click_on '非公開として保存'
+          expect(page).to have_content 'Item was successfully updated.'
+          expect(page).to have_content 'この商品は非公開です'
+        end.to change { item.purchase_requests.count }.from(1).to(0)
+      end
     end
   end
 


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/58

商品が公開から非公開に更新されたときに、紐づく購入希望オブジェクトを削除し、購入希望者を0にする機能を追加した。