### PR TITLE
購入希望がついていた商品が取り下げられた際のDiscord通知を実装した

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,9 @@ class ItemsController < ApplicationController
 
   # DELETE /items/1
   def destroy
+    requesting_users = @item.requesting_users.to_a
     @item.destroy!
+    DiscordNotifier.with(item: @item, requesting_users:).item_unlisted.notify_now if requesting_users.present?
     redirect_to items_url, notice: 'Item was successfully destroyed.', status: :see_other
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,14 @@ class ItemsController < ApplicationController
   def update
     set_unpublished
     if @item.update(item_params)
-      @item.purchase_requests.destroy_all if @item.changed_to_unpublished_from_listed?
       DiscordNotifier.with(item: @item).item_listed.notify_now if @item.changed_to_listed_from_unpublished?
+      if @item.changed_to_unpublished_from_listed?
+        requesting_users = @item.requesting_users.to_a
+        if requesting_users.present?
+          @item.purchase_requests.destroy_all
+          DiscordNotifier.with(item: @item, requesting_users:).item_unlisted.notify_now
+        end
+      end
       redirect_to @item, notice: 'Item was successfully updated.', status: :see_other
     else
       render :edit, status: :unprocessable_entity

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -41,4 +41,19 @@ class DiscordNotifier < AbstractNotifier::Base
       body: "<@#{item.user.uid}> さんの「#{item.name}」は購入希望者がつかずに出品が終了しました。"
     )
   end
+
+  def item_unlisted(params = {})
+    params.merge!(@params)
+    item = params[:item]
+    requesting_users = params[:requesting_users]
+
+    body = <<~TEXT.chomp
+      #{item.user.name} さんの「#{item.name}」の出品が取り下げられました。
+      TO: #{requesting_users.map { |user| "<@#{user.uid}> さん" }.join(', ')}
+    TEXT
+
+    notification(
+      body:
+    )
+  end
 end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/104

購入希望がついていた商品が取り下げられた際のDiscord通知を実装した。
商品の取り下げ = 商品の削除と、商品が公開から非公開に変わったとき（非公開に変わると購入希望も削除される仕様）