### PR TITLE
商品の購入希望期限を年月日のみで設定できるようにした

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -31,8 +31,7 @@ class Item < ApplicationRecord
   private
 
   def deadline_later_than_today
-    # TODO: 日付だけの入力を受け付ける修正をする際に、境界値としてTime.current.beginning_of_dayが適切なのか、テストも含め検討する
-    return unless deadline < Time.current.beginning_of_day
+    return if deadline.present? && deadline >= Time.current.beginning_of_day
 
     errors.add(:deadline, "can't be earlier than today")
   end

--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -25,7 +25,7 @@
     = form.text_field :payment_method, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
   .my-5
     = form.label :deadline
-    = form.datetime_field :deadline, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
+    = form.date_field :deadline, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
   .my-5
     = form.label :images
     - item.images.includes(:blob).find_each do |image|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ user4 = User.fourth
     price: 1000,
     shipping_cost_covered: true,
     payment_method: '楽天ペイ',
-    deadline: Time.current.next_month,
+    deadline: Time.current.next_month.beginning_of_day,
     status: :listed
   )
 end
@@ -35,7 +35,7 @@ end
     price: 1000,
     shipping_cost_covered: true,
     payment_method: 'PayPay',
-    deadline: Time.current.yesterday,
+    deadline: Time.current.yesterday.beginning_of_day,
     status: :listed
   )
   item.save!(validate: false)
@@ -47,7 +47,7 @@ user1.items.new(
   price: 1000,
   shipping_cost_covered: true,
   payment_method: '楽天ペイ',
-  deadline: Time.current.prev_month,
+  deadline: Time.current.prev_month.beginning_of_day,
   status: :buyer_selected,
   buyer: user2
 ).save!(validate: false)

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     price { 1000 }
     shipping_cost_covered { true }
     payment_method { 'PayPay' }
-    deadline { Time.current.tomorrow }
+    deadline { Time.current.tomorrow.beginning_of_day }
     user { nil }
     status { 0 }
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Item, type: :model do
       item.valid?
       expect(item.errors[:deadline]).to be_empty
     end
+
+    it 'validates that the deadline can be beginning of today' do
+      item = FactoryBot.build(:item, user: alice, deadline: Time.current.beginning_of_day)
+      item.valid?
+      expect(item.errors[:deadline]).to be_empty
+    end
   end
 
   describe '#changed_to_listed_from_unpublished?' do


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/61

商品の購入希望期限を年月日のみで設定できるようにし、テスト・開発環境用のデータもそれに則ったものに修正した。