### PR TITLE
購入希望の締め切り〜翌朝の抽選・通知時間までの間、購入希望の状態や商品状態を追加・削除・編集できないようにした

### DIFF
--- a/app/views/items/_item_button.html.slim
+++ b/app/views/items/_item_button.html.slim
@@ -1,8 +1,11 @@
 - if item.user == current_user
-  - unless item.buyer_selected?
+  - if (item.listed? && item.deadline.tomorrow > Time.current) || item.unpublished?
     = link_to 'Edit this item', edit_item_path(item), class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium'
-  .inline-block.ml-2
-    = button_to 'Destroy this item', item, method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium'
+    .inline-block.ml-2
+      = button_to 'Destroy this item', item, method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium'
+  - elsif item.buyer_selected?
+    .inline-block.ml-2
+      = button_to 'Destroy this item', item, method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium'
 - elsif item.listed?
   - if current_users_purchase_request.present? && item.deadline.tomorrow > Time.current
     .inline-block.mr-2

--- a/app/views/items/_item_button.html.slim
+++ b/app/views/items/_item_button.html.slim
@@ -4,9 +4,9 @@
   .inline-block.ml-2
     = button_to 'Destroy this item', item, method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium'
 - elsif item.listed?
-  - if current_users_purchase_request.present?
+  - if current_users_purchase_request.present? && item.deadline.tomorrow > Time.current
     .inline-block.mr-2
       = button_to '購入希望を取り消す', item_purchase_request_path(item, current_users_purchase_request), method: :delete, class: 'mt-2 rounded-lg py-3 px-5 bg-red-600 text-white font-medium'
-  - else
+  - elsif item.deadline.tomorrow > Time.current
     .inline-block.mr-2
       = button_to '購入希望を出す', item_purchase_requests_path(item), class: 'mt-2 rounded-lg py-3 px-5 bg-blue-600 text-white font-medium'

--- a/app/views/items/_item_status_label.html.slim
+++ b/app/views/items/_item_status_label.html.slim
@@ -1,3 +1,7 @@
+- if item.listed? && item.deadline.tomorrow < Time.current
+  p.py-2.px-3.bg-red-50.mb-5.text-red-500.font-medium.rounded-lg
+    | 購入者の抽選待ちです
+
 - if item.user == current_user
   - if item.buyer_selected?
     p.py-2.px-3.bg-yellow-300.mb-5.text-yellow-800.font-medium.rounded-lg

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -22,5 +22,12 @@ FactoryBot.define do
       name { '購入者確定済みの商品' }
       status { 2 }
     end
+
+    factory :closed_yesterday_and_not_buyer_selected_item do
+      name { '昨日締め切りかつ抽選前の商品' }
+      deadline { Time.current.yesterday.beginning_of_day }
+
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,11 +21,12 @@ RSpec.describe Item, type: :model do
   end
 
   describe '.closed_yesterday' do
-    it 'returns items whose deadline is yesterday' do
-      closed_yesterday_item = FactoryBot.build(:item, user: alice, deadline: Time.current.yesterday)
-      closed_yesterday_item.save!(validate: false)
+    it 'only returns listed items whose deadline is yesterday' do
+      closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
       FactoryBot.create(:item, user: alice, deadline: Time.current.beginning_of_day)
       FactoryBot.create(:item, user: alice, deadline: Time.current.tomorrow)
+      FactoryBot.create(:buyer_selected_item, user: alice)
+      FactoryBot.create(:unpublished_item, user: alice)
 
       expect(Item.closed_yesterday).to contain_exactly closed_yesterday_item
     end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -160,6 +160,18 @@ RSpec.describe 'Items', type: :system do
       end
     end
 
+    context 'when user checks their own item between its deadline and lottery' do
+      it 'user can see a label about waiting for lottery' do
+        closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
+
+        sign_in alice
+        visit item_path(closed_yesterday_item)
+        expect(page).to have_content '購入者の抽選待ちです'
+        expect(page).not_to have_button 'Edit this item'
+        expect(page).not_to have_button 'Destroy this item'
+      end
+    end
+
     context "when user checks another user's item" do
       it 'user can see a label about the status of an each item' do
         currently_requesting_item = FactoryBot.create(:item, user: bob)

--- a/spec/system/purchase_requests_spec.rb
+++ b/spec/system/purchase_requests_spec.rb
@@ -47,4 +47,27 @@ RSpec.describe 'PurchaseRequests', type: :system do
       expect(page).not_to have_button '購入希望を出す'
     end
   end
+
+  context 'when user checks an item between its deadline and lottery' do
+    let(:closed_yesterday_item) { FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice) }
+
+    it "user can see a label about waiting for lottery and can't create a purchase request" do
+      sign_in bob
+      visit item_path(closed_yesterday_item)
+      expect(page).to have_content '購入者の抽選待ちです'
+      expect(page).not_to have_button '購入希望を出す'
+    end
+
+    context 'when user checks their requesting item between its deadline and lottery' do
+      it "user can see a label about waiting for lottery and can't cancel a purchase request" do
+        FactoryBot.create(:purchase_request, user: bob, item: closed_yesterday_item)
+
+        sign_in bob
+        visit item_path(closed_yesterday_item)
+        expect(page).to have_content '購入者の抽選待ちです'
+        expect(page).to have_content '購入希望を出しています'
+        expect(page).not_to have_button '購入希望を取り消す'
+      end
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/90
- https://github.com/junohm410/fjord-flea-market/issues/115

購入希望の締め切り〜翌朝の抽選・通知時間までの間、以下のようにした。

- その商品に購入希望を出せない/取り下げられない
- その商品を編集・削除できない