### PR TITLE
出品中は商品の値段を編集できないようにした

### DIFF
--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -13,7 +13,14 @@
     = form.text_field :name, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
   .my-5
     = form.label :price
-    = form.number_field :price, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
+    - if item.new_record? || item.unpublished?
+      = form.number_field :price, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
+    - else
+      = form.number_field :price, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full', readonly: true
+      p.text-gray-400.font-medium.mt-2.text-sm
+        | ※この商品は出品中です。一度出品した商品の価格は、出品中は変更できません。<br>
+        | 価格を変更したい場合は、商品を非公開にした後に価格を変更し、再度出品してください。<br>
+        | 商品を非公開にすると、出品が取り消された扱いとなり、既存の購入希望は全て取り消され、購入希望者にその旨の通知が送られます。
   .my-5
     = form.label :description
     = form.text_area :description, rows: 4, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -52,6 +52,39 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe 'validate price_cannot_be_changed_when_listed' do
+    let(:listed_item) { FactoryBot.create(:item, user: alice) }
+    let(:unpublished_item) { FactoryBot.create(:unpublished_item, user: alice) }
+
+    context 'when the item is listed' do
+      it 'validates that the price cannot be changed' do
+        listed_item.update(price: 2000)
+        expect(listed_item.errors[:price]).to include 'cannot be changed while the item is listed'
+      end
+
+      it 'validates that other columns except price can be changed' do
+        listed_item.update(name: '更新後の商品名')
+        expect(listed_item.errors[:price]).to be_empty
+      end
+    end
+
+    context 'when the item is unpublished' do
+      it 'validates that the price can be changed' do
+        unpublished_item.update(price: 2000)
+        expect(unpublished_item.errors[:price]).to be_empty
+      end
+    end
+
+    context 'when the item is changed from unpublished to listed' do
+      it 'validates that the price can be changed' do
+        unpublished_item.price = 2000
+        unpublished_item.status = 'listed'
+        unpublished_item.valid?
+        expect(unpublished_item.errors[:price]).to be_empty
+      end
+    end
+  end
+
   describe '#changed_to_listed_from_unpublished?' do
     context 'when an item status has changed from unpublished to listed' do
       it 'returns true' do

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe 'Items', type: :system do
         end.to change { item.purchase_requests.count }.from(1).to(0)
       end
     end
+
+    context 'when user wants to change price of an item' do
+      it "user can't change price of a listed item" do
+        sign_in alice
+        visit item_path(item)
+        click_on 'Edit this item'
+        expect(page).to have_content '※この商品は出品中です。一度出品した商品の価格は、出品中は変更できません。'
+        expect(page).to have_field 'Price', readonly: true
+      end
+
+      it 'user can change price of an unpublished item' do
+        sign_in alice
+        visit item_path(unpublished_item)
+        click_on 'Edit this item'
+        expect(page).to have_field 'Price', readonly: false
+        fill_in 'Price', with: 2000
+        click_on '出品する'
+        expect(page).to have_content 'Item was successfully updated.'
+        expect(page).to have_content '2000'
+      end
+    end
   end
 
   describe 'indexing items' do


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/43

出品中は、商品の価格を変更して更新できないようにバリデーションを追加した。
また、フォーム上でも価格のinputをreadonlyにし、ユーザーに向けた説明文を追加した。