### PR TITLE
ログイン後とログイン前でrootのルーティングを分けた

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,9 @@ Rails.application.routes.draw do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
 
+  authenticated do
+    root to: "items#index", as: :authenticated_root
+  end
+
   root to: "welcome#index"
 end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/96

deviseが提供する`ActionDispatch::Routing::Mapper#authenticated`を使い、認証後のrootを商品一覧ページに設定した。
以下はメソッドのDocと参考記事。

- https://www.rubydoc.info/github/plataformatec/devise/ActionDispatch%2FRouting%2FMapper:authenticated
- [Devise入門 64のレシピ \- 猫Rails](https://nekorails.hatenablog.com/entry/2021/03/18/110200#028-%E7%8B%AC%E8%87%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E3%82%92%E5%AE%9A%E7%BE%A9%E3%81%99%E3%82%8B)