### PR TITLE
「締切後〜抽選前」「購入者確定後」の商品を編集できないようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,5 +82,6 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'launchy'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.0.0)
     chronic (0.10.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
@@ -167,6 +168,9 @@ GEM
     jwt (2.8.2)
       base64
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
     logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -454,6 +458,7 @@ DEPENDENCIES
   factory_bot_rails
   image_processing (~> 1.2)
   importmap-rails
+  launchy
   omniauth-discord
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ItemsController < ApplicationController
-  before_action :set_item, only: %i[edit update destroy]
+  before_action :set_item, only: %i[update destroy]
 
   # GET /items
   def index
@@ -19,7 +19,9 @@ class ItemsController < ApplicationController
   end
 
   # GET /items/1/edit
-  def edit; end
+  def edit
+    @item = current_user.items.editable.find(params[:id])
+  end
 
   # POST /items
   def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,6 +19,7 @@ class Item < ApplicationRecord
   validate :price_cannot_be_changed_when_listed, on: :update
 
   scope :accessible_for, ->(user) { where(user:).or(not_unpublished) }
+  scope :editable, -> { listed.where('deadline >= ?', Time.current.beginning_of_day).or(unpublished) }
   scope :closed_yesterday, -> { listed.where('deadline < ?', Time.current.beginning_of_day) }
 
   def changed_to_listed_from_unpublished?

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -29,5 +29,13 @@ FactoryBot.define do
 
       to_create { |instance| instance.save(validate: false) }
     end
+
+    factory :deadline_passed_once_and_not_buyer_selected_item do
+      name { '一度締切が過ぎて、かつ購入者がつかなかった商品' }
+      status { 1 }
+      deadline { Time.current.yesterday.beginning_of_day }
+
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
       status { 2 }
     end
 
-    factory :closed_yesterday_and_not_buyer_selected_item do
+    factory :closed_yesterday_and_waiting_for_the_lottery_item do
       name { '昨日締め切りかつ抽選前の商品' }
       deadline { Time.current.yesterday.beginning_of_day }
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe '.editable' do
+    it 'returns items that are not buyer_selected' do
+      listing_item = FactoryBot.create(:item, user: alice)
+      unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
+      done_lottery_once_and_not_buyer_selected_item = FactoryBot.create(:deadline_passed_once_and_not_buyer_selected_item, user: alice)
+      FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
+      FactoryBot.create(:buyer_selected_item, user: alice)
+
+      expect(Item.editable).to contain_exactly(listing_item, unpublished_item, done_lottery_once_and_not_buyer_selected_item)
+    end
+  end
+
   describe '.closed_yesterday' do
     it 'only returns listed items whose deadline is yesterday' do
       closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Item, type: :model do
       listing_item = FactoryBot.create(:item, user: alice)
       unpublished_item = FactoryBot.create(:unpublished_item, user: alice)
       done_lottery_once_and_not_buyer_selected_item = FactoryBot.create(:deadline_passed_once_and_not_buyer_selected_item, user: alice)
-      FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
+      FactoryBot.create(:closed_yesterday_and_waiting_for_the_lottery_item, user: alice)
       FactoryBot.create(:buyer_selected_item, user: alice)
 
       expect(Item.editable).to contain_exactly(listing_item, unpublished_item, done_lottery_once_and_not_buyer_selected_item)
@@ -34,7 +34,7 @@ RSpec.describe Item, type: :model do
 
   describe '.closed_yesterday' do
     it 'only returns listed items whose deadline is yesterday' do
-      closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
+      closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_waiting_for_the_lottery_item, user: alice)
       FactoryBot.create(:item, user: alice, deadline: Time.current.beginning_of_day)
       FactoryBot.create(:item, user: alice, deadline: Time.current.tomorrow)
       FactoryBot.create(:buyer_selected_item, user: alice)

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'Items', type: :system do
         sign_in alice
         visit item_path(closed_yesterday_item)
         expect(page).to have_content '購入者の抽選待ちです'
-        expect(page).not_to have_button 'Edit this item'
+        expect(page).not_to have_link 'Edit this item'
         expect(page).not_to have_button 'Destroy this item'
       end
     end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe 'Items', type: :system do
 
     context 'when user checks their own item between its deadline and lottery' do
       it 'user can see a label about waiting for lottery' do
-        closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice)
+        closed_yesterday_item = FactoryBot.create(:closed_yesterday_and_waiting_for_the_lottery_item, user: alice)
 
         sign_in alice
         visit item_path(closed_yesterday_item)

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -176,8 +176,13 @@ RSpec.describe 'Items', type: :system do
         sign_in alice
         visit item_path(unpublished_item)
         expect(page).to have_content 'この商品は非公開です'
+        expect(page).to have_link 'Edit this item'
+        expect(page).to have_button 'Destroy this item'
+
         visit item_path(buyer_selected_item)
         expect(page).to have_content '購入者が確定しました'
+        expect(page).not_to have_link 'Edit this item'
+        expect(page).to have_button 'Destroy this item'
       end
     end
 

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -132,6 +132,20 @@ RSpec.describe 'Items', type: :system do
         expect(page).to have_content '2000'
       end
     end
+
+    context 'when user wants to edit an unpublished item whose deadline has passed once and no one has been selected as a buyer' do
+      it 'user can edit it and list it again' do
+        target_item = FactoryBot.create(:deadline_passed_once_and_not_buyer_selected_item, user: alice)
+        sign_in alice
+        visit item_path(target_item)
+        click_on 'Edit this item'
+        fill_in 'Name', with: '再出品商品'
+        fill_in 'Deadline', with: Time.current.tomorrow
+        click_on '出品する'
+        expect(page).to have_content 'Item was successfully updated.'
+        expect(page).to have_content '再出品商品'
+      end
+    end
   end
 
   describe 'indexing items' do

--- a/spec/system/purchase_requests_spec.rb
+++ b/spec/system/purchase_requests_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'PurchaseRequests', type: :system do
   end
 
   context 'when user checks an item between its deadline and lottery' do
-    let(:closed_yesterday_item) { FactoryBot.create(:closed_yesterday_and_not_buyer_selected_item, user: alice) }
+    let(:closed_yesterday_item) { FactoryBot.create(:closed_yesterday_and_waiting_for_the_lottery_item, user: alice) }
 
     it "user can see a label about waiting for lottery and can't create a purchase request" do
       sign_in bob


### PR DESCRIPTION
- https://github.com/users/junohm410/projects/5/views/1?pane=issue&itemId=72503309

「締切後〜抽選前」「購入者確定後」の商品を編集できないようにした。