### PR TITLE
ユーザーがDiscordのプロフィールを編集したら、アプリ内のDBのユーザー情報も更新されるようにした

### DIFF
--- a/app/models/discord_bot.rb
+++ b/app/models/discord_bot.rb
@@ -18,25 +18,7 @@ class DiscordBot
     end
 
     @bot.member_update do |event|
-      uid = event.user.id
-      updated_member = JSON.parse(Discordrb::API::User.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", uid))
-
-      name = updated_member['username']
-      avatar_url = avatar_url(uid, updated_member['avatar'])
-
-      user = User.find_by(uid:)
-      if user
-        user.update!(name:) if user.name != name
-        user.update!(avatar_url:) if user.avatar_url != avatar_url
-      end
-    end
-  end
-
-  def avatar_url(uid, avatar_id)
-    if avatar_id
-      Discordrb::API::User.avatar_url(uid, avatar_id)
-    else
-      Discordrb::API::User.default_avatar
+      User.update_by_member_updating_event(event)
     end
   end
 end

--- a/app/models/discord_bot.rb
+++ b/app/models/discord_bot.rb
@@ -16,5 +16,27 @@ class DiscordBot
     @bot.member_leave do |event|
       User.remove_by_member_leaving_event(event)
     end
+
+    @bot.member_update do |event|
+      uid = event.user.id
+      updated_member = JSON.parse(Discordrb::API::User.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", uid))
+
+      name = updated_member['username']
+      avatar_url = avatar_url(uid, updated_member['avatar'])
+
+      user = User.find_by(uid:)
+      if user
+        user.update!(name:) if user.name != name
+        user.update!(avatar_url:) if user.avatar_url != avatar_url
+      end
+    end
+  end
+
+  def avatar_url(uid, avatar_id)
+    if avatar_id
+      Discordrb::API::User.avatar_url(uid, avatar_id)
+    else
+      Discordrb::API::User.default_avatar
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,39 +13,51 @@ class User < ApplicationRecord
   validates :uid, presence: true, uniqueness: { scope: :provider }
   validates :provider, presence: true, inclusion: { in: %w[discord] }
 
-  def self.find_or_create_from_auth_hash!(auth_hash)
-    provider = auth_hash[:provider]
-    uid = auth_hash[:uid]
-    name = auth_hash[:info][:name]
-    avatar = auth_hash[:extra][:raw_info][:avatar]
+  class << self
+    def find_or_create_from_auth_hash!(auth_hash)
+      provider = auth_hash[:provider]
+      uid = auth_hash[:uid]
+      name = auth_hash[:info][:name]
+      avatar = auth_hash[:extra][:raw_info][:avatar]
 
-    # サーバーメンバーではない場合リクエストに失敗してログインできない
-    Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV['DISCORD_SERVER_ID'], uid)
+      # サーバーメンバーではない場合リクエストに失敗してログインできない
+      Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV['DISCORD_SERVER_ID'], uid)
 
-    User.find_or_create_by!(provider:, uid:) do |user|
-      user.name = name
-      user.avatar_url = avatar ? Discordrb::API::User.avatar_url(uid, avatar) : Discordrb::API::User.default_avatar
+      User.find_or_create_by!(provider:, uid:) do |user|
+        user.name = name
+        user.avatar_url = make_avatar_url(uid, avatar)
+      end
     end
-  end
 
-  def self.remove_by_member_leaving_event(event)
-    uid = event.user.id
-    user = find_by(uid:)
-    user&.destroy
-  end
+    def remove_by_member_leaving_event(event)
+      uid = event.user.id
+      user = find_by(uid:)
+      user&.destroy
+    end
 
-  def self.update_by_member_updating_event(event)
-    uid = event.user.id
-    updated_member = JSON.parse(Discordrb::API::User.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", uid))
+    def update_by_member_updating_event(event)
+      uid = event.user.id
+      updated_member = JSON.parse(Discordrb::API::User.resolve("Bot #{ENV['DISCORD_BOT_TOKEN']}", uid))
 
-    name = updated_member['username']
-    avatar = updated_member['avatar']
-    avatar_url = avatar ? Discordrb::API::User.avatar_url(uid, avatar) : Discordrb::API::User.default_avatar
+      name = updated_member['username']
+      avatar = updated_member['avatar']
+      avatar_url = make_avatar_url(uid, avatar)
 
-    user = User.find_by(uid:)
-    return unless user
+      user = User.find_by(uid:)
+      return unless user
 
-    user.update!(name:) if user.name != name
-    user.update!(avatar_url:) if user.avatar_url != avatar_url
+      user.update!(name:) if user.name != name
+      user.update!(avatar_url:) if user.avatar_url != avatar_url
+    end
+
+    private
+
+    def make_avatar_url(uid, avatar)
+      if avatar
+        Discordrb::API::User.avatar_url(uid, avatar)
+      else
+        Discordrb::API::User.default_avatar
+      end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,14 +17,18 @@ class User < ApplicationRecord
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]
     name = auth_hash[:info][:name]
-    avatar_url = auth_hash[:info][:image]
+    avatar = auth_hash[:extra][:raw_info][:avatar]
 
     # サーバーメンバーではない場合リクエストに失敗してログインできない
     Discordrb::API::Server.resolve_member("Bot #{ENV['DISCORD_BOT_TOKEN']}", ENV['DISCORD_SERVER_ID'], uid)
 
     User.find_or_create_by!(provider:, uid:) do |user|
       user.name = name
-      user.avatar_url = avatar_url
+      user.avatar_url = if avatar
+                          Discordrb::API::User.avatar_url(uid, avatar)
+                        else
+                          Discordrb::API::User.default_avatar
+                        end
     end
   end
 

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -2,8 +2,7 @@
   li.mt-3
     = simple_format comment.content
     small.block.mt-2
-      - avatar_url = comment.user.avatar_url.presence || 'https://cdn.discordapp.com/embed/avatars/0.png'
-      = image_tag(avatar_url, class: 'inline w-6 h-6 rounded-full mr-2')
+      = image_tag(comment.user.avatar_url, class: 'inline w-6 h-6 rounded-full mr-2')
       | #{comment.user.name}さん - #{l(comment.created_at, format: :long)}
       - if comment.user == current_user
         .flex.gap-1

--- a/app/views/items/_item.html.slim
+++ b/app/views/items/_item.html.slim
@@ -14,8 +14,7 @@ div id="#{dom_id item}"
           = item.payment_method
   .mt-3
     p.font-medium
-      - avatar_url = item.user.avatar_url.presence || 'https://cdn.discordapp.com/embed/avatars/0.png'
-      = image_tag(avatar_url, class: 'inline-block mr-2 w-8 h-8 rounded-full')
+      = image_tag(item.user.avatar_url, class: 'inline-block mr-2 w-8 h-8 rounded-full')
       | #{item.user.name} さんの出品
   .mt-5
     h3.text-lg.font-semibold.text-gray-800

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ UID_DIGITS = 19
     uid: format("%0#{UID_DIGITS}d", SecureRandom.random_number(10**UID_DIGITS)),
     name: "user#{n + 1}",
     provider: 'discord',
-    avatar_url: nil
+    avatar_url: 'https://cdn.discordapp.com/embed/avatars/0.png'
   )
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe User, type: :model do
         provider: 'discord',
         uid:,
         info: {
-          name: 'bob',
-          image: 'https://cdn.discordapp.com/embed/avatars/1.png'
+          name: 'bob'
+        },
+        extra: {
+          raw_info: {
+            avatar: nil
+          }
         }
       }
     end
@@ -26,7 +30,7 @@ RSpec.describe User, type: :model do
         expect(user.provider).to eq 'discord'
         expect(user.uid).to eq '2345678'
         expect(user.name).to eq 'bob'
-        expect(user.avatar_url).to eq 'https://cdn.discordapp.com/embed/avatars/1.png'
+        expect(user.avatar_url).to eq 'https://cdn.discordapp.com/embed/avatars/0.png'
         expect(User.find_or_create_from_auth_hash!(auth_hash)).to eq User.find_by(uid:)
       end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -49,8 +49,12 @@ RSpec.describe 'Users', type: :system do
       provider: 'discord',
       uid:,
       info: {
-        name: 'alice',
-        image: 'https://cdn.discordapp.com/embed/avatars/1.png'
+        name: 'alice'
+      },
+      extra: {
+        raw_info: {
+          avatar: nil
+        }
       }
     }
     OmniAuth::AuthHash.new(auth_hash)


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/49

ユーザーがDiscordのプロフィールを編集したら、アプリ内のDBのユーザー情報も更新されるようにした。

また本PRによる変更で、アバター画像を設定していないユーザーが初回ログインした際に、Userテーブルのavatar_urlカラムにnilではなくDiscordのデフォルトのアバター画像のURLが入るようになった。