### PR TITLE
商品編集時に、すでに添付されている画像を選択して削除できる機能を実装

### DIFF
--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -31,10 +31,18 @@
   .my-5
     = form.label :deadline
     = form.date_field :deadline, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
+  - if item.images.attached?
+    .my-5
+      label 現在添付されている商品画像
+      p.text-gray-400.font-medium.mt-2.text-sm
+        | 画像を削除したい場合はチェックボックスを外してください。
+      .flex.items-end.mt-2
+        = form.collection_check_boxes :images, item.images.includes(:blob), :signed_id, :signed_id, include_hidden: false do |b|
+          .mr-2
+            = b.label { image_tag b.object.variant(resize_to_fit: [150, 100]) }
+            = b.check_box checked: true
   .my-5
     = form.label :images
-    - item.images.includes(:blob).find_each do |image|
-      = form.hidden_field :images, multiple: true, value: image.signed_id
     = form.file_field :images, multiple: true, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
   .inline
     = form.submit '非公開として保存', class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium cursor-pointer'

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe 'Items', type: :system do
         expect(page).to have_content '編集済み商品'
       end
 
+      it 'user can select and delete already existing item images' do
+        item = FactoryBot.create(:item, user: alice)
+        item.images.attach(io: File.open(Rails.root.join('spec/files/book.png')), filename: 'book.png')
+        item.images.attach(io: File.open(Rails.root.join('spec/files/books.png')), filename: 'books.png')
+
+        sign_in alice
+        visit item_path(item)
+        click_on '商品を編集する'
+        expect do
+          expect(page).to have_selector("img[src$='book.png']")
+          expect(page).to have_selector("img[src$='books.png']")
+          find("img[src$='book.png']").click
+          click_on '出品する'
+          expect(page).to have_content 'Item was successfully updated.'
+        end.to change { item.images.count }.from(2).to(1)
+        expect(page).to have_selector("img[src$='books.png']")
+        click_on '商品を編集する'
+        expect(page).not_to have_selector("img[src$='book.png']")
+        expect(page).to have_selector("img[src$='books.png']")
+      end
+
       it 'user can destroy their own item' do
         sign_in alice
         visit item_path(item)


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/138

商品編集時にすでに添付されている画像を表示し、選択して削除できる機能を実装した。