### PR TITLE
商品の変更内容を出品状態のまま保存する際のsubmitボタンの表記を修正

### DIFF
--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -47,4 +47,5 @@
   .inline
     = form.submit '非公開として保存', class: 'mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium cursor-pointer'
   .inline
-    = form.submit '出品する', class: 'ml-2 rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer'
+    - list_buttons_label = item.persisted? && item.listed? ? '変更する' : '出品する'
+    = form.submit list_buttons_label, class: 'ml-2 rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer'

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Items', type: :system do
         visit item_path(item)
         click_on '商品を編集する'
         fill_in '商品名', with: '編集済み商品'
-        click_on '出品する'
+        click_on '変更する'
         expect(page).to have_content 'Item was successfully updated.'
         expect(page).to have_content '編集済み商品'
       end
@@ -73,7 +73,7 @@ RSpec.describe 'Items', type: :system do
           expect(page).to have_selector("img[src$='book.png']")
           expect(page).to have_selector("img[src$='books.png']")
           find("img[src$='book.png']").click
-          click_on '出品する'
+          click_on '変更する'
           expect(page).to have_content 'Item was successfully updated.'
         end.to change { item.images.count }.from(2).to(1)
         expect(page).to have_selector("img[src$='books.png']")


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/94

商品の変更内容を出品状態のまま保存する際のsubmitボタンの表記を修正した。