### PR TITLE
商品画像を添付した状態で、他のカラムでバリデーション違反を起こすとアプリ自体がエラーになる問題を修正

### DIFF
--- a/app/views/items/_form.html.slim
+++ b/app/views/items/_form.html.slim
@@ -31,13 +31,13 @@
   .my-5
     = form.label :deadline
     = form.date_field :deadline, class: 'block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full'
-  - if item.images.attached?
+  - if (images = item.images_attachments.includes(:blob).presence)
     .my-5
       label 現在添付されている商品画像
       p.text-gray-400.font-medium.mt-2.text-sm
         | 画像を削除したい場合はチェックボックスを外してください。
       .flex.items-end.mt-2
-        = form.collection_check_boxes :images, item.images.includes(:blob), :signed_id, :signed_id, include_hidden: false do |b|
+        = form.collection_check_boxes :images, images, :signed_id, :signed_id, include_hidden: false do |b|
           .mr-2
             = b.label { image_tag b.object.variant(resize_to_fit: [150, 100]) }
             = b.check_box checked: true

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe 'Items', type: :system do
       expect(page).to have_content 'Item was successfully created.'
       expect(page).to have_content 'この商品は非公開です'
     end
+
+    context 'when validation errors occur in non-image columns while attaching images' do
+      it 'user can see an edit form again with messages about validation errors' do
+        sign_in alice
+        visit new_item_path
+        fill_in '価格', with: 1000
+        fill_in '商品の説明', with: 'テスト商品です'
+        fill_in '購入希望の締切日', with: Time.zone.tomorrow
+        attach_file '商品画像', [
+          Rails.root.join('spec/files/book.png')
+        ]
+        expect { click_on '出品する' }.not_to raise_error
+        expect(page).to have_content '商品名を入力してください'
+      end
+    end
   end
 
   describe 'editing and destroying items' do


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/141

商品画像を添付した状態で、他のカラムでバリデーション違反を起こすとアプリ自体がエラーになる問題を修正した。