### PR TITLE
商品画像のバリデーションを実装した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'bootsnap', require: false
 gem 'image_processing', '~> 1.2'
 
 gem 'active_delivery', '~> 1.0'
+gem 'active_storage_validations'
 gem 'any_login'
 gem 'devise'
 gem 'discordrb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,11 @@ GEM
       rails-html-sanitizer (~> 1.6)
     active_delivery (1.2.0)
       ruby-next-core (~> 1.0)
+    active_storage_validations (1.1.4)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (7.1.3.4)
       activesupport (= 7.1.3.4)
       globalid (>= 0.3.6)
@@ -467,6 +472,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_delivery (~> 1.0)
+  active_storage_validations
   any_login
   bootsnap
   bullet

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,6 +15,11 @@ class Item < ApplicationRecord
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :shipping_cost_covered, inclusion: { in: [true, false] }
   validates :deadline, presence: true
+  validates :images,
+            content_type: %i[png jpg jpeg heic heif],
+            limit: { max: 5, message: 'の枚数は5枚以下にしてください' },
+            size: { less_than: 6.megabytes },
+            processable_image: true
   validate :deadline_later_than_today, unless: -> { validation_context == :select_buyer }
   validate :price_cannot_be_changed_when_listed, on: :update
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -158,6 +158,10 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      content_type_invalid: のファイル形式は %{authorized_types} のいずれかにしてください
+      limit_out_of_range: の数が許容範囲外です
+      file_size_not_less_than: のファイルサイズは %{max_size} 未満にしてください (現在のサイズは %{file_size})
+      image_not_processable: は不正な画像です
     template:
       body: 次の項目を確認してください
       header: "%{model}に%{count}個のエラーが発生しました"


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/93

商品画像のバリデーションを実装した。

- ファイルタイプ（png jpg jpeg heic heif）
- 添付できる枚数（5枚まで）
- ファイルサイズ（6MBまで）
- libvipsで処理できる画像かどうか