### PR TITLE
商品追加・更新・削除時の通知のテストの追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,12 +41,9 @@ class ItemsController < ApplicationController
     set_unpublished
     if @item.update(item_params)
       DiscordNotifier.with(item: @item).item_listed.notify_now if @item.changed_to_listed_from_unpublished?
-      if @item.changed_to_unpublished_from_listed?
-        requesting_users = @item.requesting_users.to_a
-        if requesting_users.present?
-          @item.purchase_requests.destroy_all
-          DiscordNotifier.with(item: @item, requesting_users:).item_unlisted.notify_now
-        end
+      if @item.changed_to_unpublished_from_listed? && (requesting_users = @item.requesting_users.presence)
+        @item.purchase_requests.destroy_all
+        DiscordNotifier.with(item: @item, requesting_users:).item_unlisted.notify_now
       end
       redirect_to @item, notice: 'Item was successfully updated.', status: :see_other
     else


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/105

商品のCRUDのシステムテストにおいて、通知のメソッドが呼ばれるかを確かめるexpectationを追加した。