### PR TITLE
通知のためのクラスの単体テストの追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,5 @@ jobs:
         run: bin/rails db:schema:load
       - name: Run tests
         run: bundle exec rspec
+        env:
+          DISCORD_WEBHOOK_URL: https://example.com/

--- a/app/models/discord_driver.rb
+++ b/app/models/discord_driver.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DiscordDriver
+  DEFAULT_SENDER_NAME = 'FBCフリマ'
+
   def call(params)
     client = Discordrb::Webhooks::Client.new(url: ENV['DISCORD_WEBHOOK_URL'])
 
@@ -8,7 +10,7 @@ class DiscordDriver
       embed_message = params[:embed_message]
 
       builder.content = params[:body]
-      builder.username = params[:sender_name] || 'FBCフリマ'
+      builder.username = params[:sender_name] || DEFAULT_SENDER_NAME
       add_embed(builder, embed_message) if embed_message.present?
     end
   end

--- a/app/models/embed_message_formatter.rb
+++ b/app/models/embed_message_formatter.rb
@@ -6,7 +6,7 @@ class EmbedMessageFormatter
     @user = item.user
   end
 
-  def format_embed_message
+  def execute
     {
       title: @item.name,
       url: Rails.application.routes.url_helpers.item_url(@item),

--- a/app/models/embed_message_formatter.rb
+++ b/app/models/embed_message_formatter.rb
@@ -12,9 +12,9 @@ class EmbedMessageFormatter
       url: Rails.application.routes.url_helpers.item_url(@item),
       description: @item.description,
       timestamp: @item.created_at,
-      thumbnail: { url: @user.avatar_url || 'https://cdn.discordapp.com/embed/avatars/0.png' },
+      thumbnail: { url: @user.avatar_url },
       author: { name: @user.name,
-                icon_url: @user.avatar_url || 'https://cdn.discordapp.com/embed/avatars/0.png' },
+                icon_url: @user.avatar_url },
       item_field:
     }
   end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -7,7 +7,7 @@ class DiscordNotifier < AbstractNotifier::Base
     params.merge!(@params)
     item = params[:item]
 
-    embed_message = EmbedMessageFormatter.new(item).format_embed_message
+    embed_message = EmbedMessageFormatter.new(item).execute
 
     notification(
       body: '新しい商品が出品されました！',
@@ -25,7 +25,7 @@ class DiscordNotifier < AbstractNotifier::Base
       CC: #{no_selected_users.map { |user| "<@#{user.uid}> さん" }.join(', ')}
     TEXT
 
-    embed_message = EmbedMessageFormatter.new(item).format_embed_message
+    embed_message = EmbedMessageFormatter.new(item).execute
 
     notification(
       body:,

--- a/spec/models/discord_driver_spec.rb
+++ b/spec/models/discord_driver_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DiscordDriver, type: :model do
+  let(:alice) { FactoryBot.create(:user) }
+  let(:item) { FactoryBot.create(:item, user: alice) }
+
+  before do
+    stub_request(:post, ENV['DISCORD_WEBHOOK_URL'])
+  end
+
+  describe '#call' do
+    context 'when a sender name is designated' do
+      before do
+        DiscordDriver.new.call(
+          {
+            body: '新しい商品が出品されました！',
+            sender_name: 'ピヨルド',
+            embed_message: EmbedMessageFormatter.new(item).execute
+          }
+        )
+      end
+
+      it 'sends a POST request to Discord to send a message using the designated name' do
+        expect(WebMock).to have_requested(:post, ENV['DISCORD_WEBHOOK_URL'])
+          .with(body: hash_including(:embeds,
+                                     content: '新しい商品が出品されました！',
+                                     username: 'ピヨルド'))
+      end
+    end
+
+    context "when a sender name isn't designated" do
+      before do
+        DiscordDriver.new.call(
+          {
+            body: '新しい商品が出品されました！',
+            embed_message: EmbedMessageFormatter.new(item).execute
+          }
+        )
+      end
+
+      it 'sends a POST request to Discord to send a message using a default name' do
+        expect(WebMock).to have_requested(:post, ENV['DISCORD_WEBHOOK_URL'])
+          .with(body: hash_including(:embeds,
+                                     content: '新しい商品が出品されました！',
+                                     username: DiscordDriver::DEFAULT_SENDER_NAME))
+      end
+    end
+
+    context 'when no embed messages is given' do
+      before do
+        DiscordDriver.new.call({ body: '出品が取り下げられました。' })
+      end
+
+      it 'sends a POST request to Discord to send a message without embed messages' do
+        expect(WebMock).to have_requested(:post, ENV['DISCORD_WEBHOOK_URL'])
+          .with(body: hash_including(content: '出品が取り下げられました。',
+                                     embeds: []))
+      end
+    end
+  end
+end

--- a/spec/models/embed_message_formatter_spec.rb
+++ b/spec/models/embed_message_formatter_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbedMessageFormatter, type: :model do
+  describe '#execute' do
+    let(:alice) { FactoryBot.create(:user) }
+
+    context 'when the shipping cost is paid by the lister' do
+      let(:item) do
+        FactoryBot.create(:item, name: 'テスト商品', description: '出品者が送料を負担するテスト商品', price: 1000,
+                                 deadline: Date.tomorrow, shipping_cost_covered: true, payment_method: 'PayPay', user: alice)
+      end
+
+      it 'returns an embedded message that says that the cost is paid by the lister' do
+        expect(EmbedMessageFormatter.new(item).execute).to eq(
+          {
+            title: 'テスト商品',
+            url: Rails.application.routes.url_helpers.item_url(item),
+            description: '出品者が送料を負担するテスト商品',
+            timestamp: item.created_at,
+            thumbnail: { url: alice.avatar_url },
+            author: { name: 'alice', icon_url: alice.avatar_url },
+            item_field: {
+              price: '¥1,000',
+              deadline: I18n.l(item.deadline),
+              shipping: '出品者',
+              payment: 'PayPay'
+            }
+          }
+        )
+      end
+    end
+
+    context 'when the shipping cost is paid by the buyer' do
+      let(:item) do
+        FactoryBot.create(:item, name: 'テスト商品', description: '購入者が送料を負担するテスト商品', price: 1000,
+                                 deadline: Date.tomorrow, shipping_cost_covered: false, payment_method: 'PayPay', user: alice)
+      end
+
+      it 'returns an embedded message that says that the cost is paid by the buyer' do
+        expect(EmbedMessageFormatter.new(item).execute).to eq(
+          {
+            title: 'テスト商品',
+            url: Rails.application.routes.url_helpers.item_url(item),
+            description: '購入者が送料を負担するテスト商品',
+            timestamp: item.created_at,
+            thumbnail: { url: alice.avatar_url },
+            author: { name: 'alice', icon_url: alice.avatar_url },
+            item_field: {
+              price: '¥1,000',
+              deadline: I18n.l(item.deadline),
+              shipping: '購入者',
+              payment: 'PayPay'
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/notifiers/discord_notifier_spec.rb
+++ b/spec/notifiers/discord_notifier_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'DiscordNotifier', type: :model do
+  let(:alice) { FactoryBot.create(:user) }
+  let(:bob) { FactoryBot.create(:user, name: 'bob') }
+  let(:carol) { FactoryBot.create(:user, name: 'carol') }
+  let(:item) { FactoryBot.create(:item, user: alice) }
+
+  describe '#item_listed' do
+    it 'sends a message about that a new item has been listed' do
+      params = { item: }
+      expected = {
+        body: '新しい商品が出品されました！',
+        embed_message: EmbedMessageFormatter.new(item).execute
+      }
+
+      expect { DiscordNotifier.with(params).item_listed.notify_now }
+        .to have_sent_notification(**expected)
+    end
+  end
+
+  describe '#buyer_selected' do
+    let(:buyer_selected_item) { FactoryBot.create(:buyer_selected_item, user: alice, buyer: bob) }
+
+    before do
+      FactoryBot.create(:purchase_request, user: bob, item: buyer_selected_item)
+      FactoryBot.create(:purchase_request, user: carol, item: buyer_selected_item)
+    end
+
+    it 'sends a message about that a buyer has been selected' do
+      params = { item: buyer_selected_item }
+      body = <<~TEXT.chomp
+        <@#{alice.uid}> さんの「#{buyer_selected_item.name}」の購入者が <@#{bob.uid}> さんに決定しました。
+        CC: <@#{carol.uid}> さん
+      TEXT
+
+      expected = { body:, embed_message: EmbedMessageFormatter.new(buyer_selected_item).execute }
+
+      expect { DiscordNotifier.with(params).buyer_selected.notify_now }
+        .to have_sent_notification(**expected)
+    end
+  end
+
+  describe '#buyer_not_selected' do
+    it 'sends a message about that a no one has been selected as a buyer' do
+      params = { item: }
+      expected = { body: "<@#{alice.uid}> さんの「#{item.name}」は購入希望者がつかずに出品が終了しました。" }
+
+      expect { DiscordNotifier.with(params).buyer_not_selected.notify_now }
+        .to have_sent_notification(**expected)
+    end
+  end
+
+  describe '#item_unlisted' do
+    before do
+      FactoryBot.create(:purchase_request, user: bob, item:)
+      FactoryBot.create(:purchase_request, user: carol, item:)
+    end
+
+    it 'sends a message about that an item has been withdrew' do
+      params = { item:, requesting_users: item.requesting_users }
+      body = <<~TEXT.chomp
+        #{alice.name} さんの「#{item.name}」の出品が取り下げられました。
+        TO: <@#{bob.uid}> さん, <@#{carol.uid}> さん
+      TEXT
+
+      expected = { body: }
+
+      expect { DiscordNotifier.with(params).item_unlisted.notify_now }
+        .to have_sent_notification(**expected)
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/145

以下のクラスの単体テストを追加した。

- DiscordNotifier
- DiscordDriver
- EmbedMessageFormatter
