### PR TITLE
購入者の抽選とその後の通知のテストの追加

### DIFF
--- a/app/models/buyer_selector.rb
+++ b/app/models/buyer_selector.rb
@@ -3,16 +3,20 @@
 class BuyerSelector
   def initialize(item)
     @item = item
-    @purchase_requests = @item.purchase_requests
   end
 
-  def select_buyer!
-    if @purchase_requests.exists?
-      buyer = @purchase_requests.sample.user
-      @item.assign_attributes(buyer:, status: :buyer_selected)
-    else
-      @item.status = :unpublished
+  def execute
+    @item.select_buyer!
+    notify_to_users
+  end
+
+  private
+
+  def notify_to_users
+    if @item.buyer_selected?
+      DiscordNotifier.with(item: @item).buyer_selected.notify_now
+    elsif @item.unpublished?
+      DiscordNotifier.with(item: @item).buyer_not_selected.notify_now
     end
-    @item.save!(context: :select_buyer)
   end
 end

--- a/lib/tasks/select_buyer.rake
+++ b/lib/tasks/select_buyer.rake
@@ -1,17 +1,8 @@
 # frozen_string_literal: true
 
 namespace :items do
-  desc 'Select winners for items whose deadline has passed and no winner has been chosen yet'
+  desc 'Select winners for items whose deadline has passed and no buyer has been selected yet'
   task select_buyers: :environment do
-    items = Item.closed_yesterday
-
-    items.find_each do |item|
-      buyer_selector = BuyerSelector.new(item)
-      buyer_selector.select_buyer!
-
-      item.reload
-      DiscordNotifier.with(item:).buyer_selected.notify_now if item.buyer_selected?
-      DiscordNotifier.with(item:).buyer_not_selected.notify_now if item.unpublished?
-    end
+    Item.closed_yesterday.find_each { |item| BuyerSelector.new(item).execute }
   end
 end

--- a/lib/tasks/select_buyer.rake
+++ b/lib/tasks/select_buyer.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :items do
-  desc 'Select winners for items whose deadline has passed and no buyer has been selected yet'
+  desc 'Select buyers for items whose deadline has passed and buyer has not been selected yet'
   task select_buyers: :environment do
     Item.closed_yesterday.find_each { |item| BuyerSelector.new(item).execute }
   end

--- a/spec/models/buyer_selector_spec.rb
+++ b/spec/models/buyer_selector_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BuyerSelector, type: :model do
+  let(:item) { instance_double(Item) }
+
+  before do
+    allow(item).to receive(:select_buyer!)
+  end
+
+  describe '#execute' do
+    before do
+      allow(item).to receive(:buyer_selected?).and_return(true)
+    end
+
+    context 'when a buyer of an item will be selected' do
+      it 'calls Item#select_buyer! then notifies buyer has been selected' do
+        expect(DiscordNotifier).to receive_message_chain(:with, :buyer_selected, :notify_now) # rubocop:disable RSpec/MessageChain
+        BuyerSelector.new(item).execute
+        expect(item).to have_received(:select_buyer!)
+      end
+    end
+
+    context 'when a buyer of an item will not be selected' do
+      before do
+        allow(item).to receive_messages(buyer_selected?: false, unpublished?: true)
+      end
+
+      it 'calls Item#select_buyer! then notifies that a buyer has not been selected' do
+        expect(DiscordNotifier).to receive_message_chain(:with, :buyer_not_selected, :notify_now) # rubocop:disable RSpec/MessageChain
+        BuyerSelector.new(item).execute
+        expect(item).to have_received(:select_buyer!)
+      end
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -97,6 +97,36 @@ RSpec.describe Item, type: :model do
     end
   end
 
+  describe '#select_buyer!' do
+    let(:item) { FactoryBot.create(:closed_yesterday_and_waiting_for_the_lottery_item, user: alice) }
+
+    context 'when item has purchase requests' do
+      before do
+        bob = FactoryBot.create(:user, name: 'bob')
+        carol = FactoryBot.create(:user, name: 'carol')
+        FactoryBot.create(:purchase_request, user: bob, item:)
+        FactoryBot.create(:purchase_request, user: carol, item:)
+      end
+
+      it 'selects a buyer and change the item status to buyer_selected' do
+        expect(item.listed?).to be true
+        expect(item.buyer).to be_nil
+        item.select_buyer!
+        expect(item.buyer_selected?).to be true
+        expect(item.buyer.name).to eq('bob').or eq('carol')
+      end
+    end
+
+    context 'when item has no purchase requests' do
+      it 'only changes the item status to unpublished' do
+        expect(item.listed?).to be true
+        expect(item.buyer).to be_nil
+        expect { item.select_buyer! }.not_to change(item, :buyer)
+        expect(item.unpublished?).to be true
+      end
+    end
+  end
+
   describe '#changed_to_listed_from_unpublished?' do
     context 'when an item status has changed from unpublished to listed' do
       it 'returns true' do


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/91

購入者の抽選とその後の通知のテストを追加した。
（同時に抽選処理周りのクラス構成を見直してリファクタリングを行った。）