### PR TITLE
production環境でのDiscord通知の際に使用するURLのホストを設定する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,7 @@ Rails.application.configure do
   AnyLogin.setup do |config|
     config.enabled = false
   end
+
+  Rails.application.routes.default_url_options[:host] = ENV["APP_HOST_NAME"]
+  Rails.application.routes.default_url_options[:protocol] = 'https'
 end


### PR DESCRIPTION
- https://github.com/junohm410/fjord-flea-market/issues/148

productionで通知が送れないバグを修正する。