### PR TITLE
商品画像のlargeバリアントをアップロード時に非同期で生成する設定を追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   has_many_attached :images do |attachable|
     attachable.variant :small, resize_to_limit: [150, 100]
     attachable.variant :medium, resize_to_limit: [200, 200]
-    attachable.variant :large, resize_to_limit: [600, 454]
+    attachable.variant :large, resize_to_limit: [600, 454], preprocessed: true
   end
 
   enum status: { listed: 0, unpublished: 1, buyer_selected: 2 }


### PR DESCRIPTION
商品画像のlargeバリアントをアップロード時に非同期で生成する設定を追加した。